### PR TITLE
Added JSCS to enforce styleguide

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   "bugs": {
     "url": "https://github.com/qw3rtman/gg/issues"
   },
+  "scripts": {
+    "test": "jscs -p airbnb lib bin"
+  },
   "homepage": "https://github.com/qw3rtman/gg",
   "engines": {
     "node": ">=0.10.0"
@@ -35,5 +38,8 @@
     "chalk": "^1.0.0",
     "cli": "^0.6.5",
     "request": "^2.53.0"
+  },
+  "devDependencies": {
+    "jscs": "~1.11.3"
   }
 }


### PR DESCRIPTION
You can run this via `npm test`

There are numerous violations of the airbnb styleguide within the lib/ and bin/ directories.
The issue is namely with your use of a single space instead of 2-space indentation.

If you'd like to pull down the PR and fix the violations,
you can then turn on Travis CI so that PRs are checked for styleguide violations.